### PR TITLE
grammar syntax highlighting when there are multiple definitions per line

### DIFF
--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -19,7 +19,7 @@ export default function prismIncludeLanguages(PrismObject) {
   // Go-style EBNF (https://pkg.go.dev/golang.org/x/exp/ebnf)
   // is a little different than EBNF that Prism supports.
   PrismObject.languages.ebnf.string.pattern = /"[^"\r\n]*"|`[^`\r\n]*`/; // support back-tick string, not single-quote
-  PrismObject.languages.ebnf.operator.pattern = /[-=…|*/!]/; // … is a range operator
-
+  PrismObject.languages.ebnf.operator.pattern = /[-=…|*/!.]/; // '…' is a range operator; '.' is end of rule
+  PrismObject.languages.ebnf.definition.pattern = /(?:^|\.)([\t ]*)[a-z]\w*(?:[ \t]+[a-z]\w*)*(?=\s*=)/im
   delete globalThis.Prism;
 }


### PR DESCRIPTION
The default EBNF highlighting for Prism assumes a definition per line ([source](https://github.com/PrismJS/prism/blob/master/components/prism-ebnf.js#L14)). But the notation we are using allows a period (`.`) to end a definition, and another could then begin on the same line.

So this fixes the highlighting to work with the notation used here.

**Before** (notice rule names after the first on the line are not highlighted in blue):
<img width="774" alt="Screen Shot 2022-09-12 at 2 10 59 PM" src="https://user-images.githubusercontent.com/2035234/189726527-bd4d6b9f-aaa6-437e-8a39-85bac453ba0a.png">

**After**:
<img width="839" alt="Screen Shot 2022-09-12 at 2 11 14 PM" src="https://user-images.githubusercontent.com/2035234/189726378-22bd19e1-4e59-4a8d-a86f-74aa5df7acc9.png">
