### PR TITLE
update spec for hex escapes in strings

### DIFF
--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -340,7 +340,7 @@ double_quoted_string_literal = `"` { !("\n" | "\x00" | `"` | `\`) | rune_escape_
 
 rune_escape_seq    = simple_escape_seq | hex_escape_seq | octal_escape_seq | unicode_escape_seq .
 simple_escape_seq  = `\` ( "a" | "b" | "f" | "n" | "r" | "t" | "v" | `\` | "'" | `"` | "?" ) .
-hex_escape_seq     = `\` "x" hex_digit hex_digit .
+hex_escape_seq     = `\` ( "x" | "X" ) hex_digit [ hex_digit ] .
 octal_escape_seq   = `\` octal_digit [ octal_digit [ octal_digit ] ] .
 unicode_escape_seq = `\` "u" hex_digit hex_digit hex_digit hex_digit |
                      `\` "U" hex_digit hex_digit hex_digit hex_digit
@@ -353,6 +353,7 @@ unicode_escape_seq = `\` "u" hex_digit hex_digit hex_digit hex_digit |
 "A string with \"nested quotes\" in it"
 'Another with \'nested quotes\' inside'
 "Some whitespace:\n\r\t\v"
+'Hex escaped bytes: \x01\x2\X03\X4'
 'A string with a literal back-slash \\ in it'
 "A string that has a NULL character in hex: \x00"
 "Another with a NULL in octal: \00"


### PR DESCRIPTION
This fixes hex escapes to correctly reflect that a single digit is acceptable. Also, it reflects the fact that capital X may also be used for hex escapes, not just lower-case x.

This has been (incorrectly?) supported in buf, but it turns out that ([despite the official docs](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#string_literals)) it was not actually supported by `protoc`.

As of https://github.com/protocolbuffers/protobuf/pull/10757 it will be supported in both `protoc` and buf, so this spec should reflect it.