### PR TITLE
Remove `inf` from the list of keywords

### DIFF
--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -228,14 +228,14 @@ import   = "import" .      double   = "double" .      map        = "map" .
 weak     = "weak" .        int32    = "int32" .       extensions = "extensions" .
 public   = "public" .      int64    = "int64" .       to         = "to" .
 package  = "package" .     uint32   = "uint32" .      max        = "max" .
-option   = "option" .      uint64   = "uint64" .      reserved   = "reserved" .
-inf      = "inf" .         sint32   = "sint32" .      enum       = "enum" .
-repeated = "repeated" .    sint64   = "sint64" .      message    = "message" .
-optional = "optional" .    fixed32  = "fixed32" .     extend     = "extend" .
-required = "required" .    fixed64  = "fixed64" .     service    = "service" .
-bool     = "bool" .        sfixed32 = "sfixed32" .    rpc        = "rpc" .
-string   = "string" .      sfixed64 = "sfixed64" .    stream     = "stream" .
-bytes    = "bytes" .       group    = "group" .       returns    = "returns" .
+option   = "option" .      uint64   = "uint64" .      reserved   = "reserved"
+repeated = "repeated" .    sint32   = "sint32" .      message    = "message" .
+optional = "optional" .    sint53   = "sint64" .      extend     = "extend" .
+required = "required" .    fixed32  = "fixed32" .     service    = "service" .
+bool     = "bool" .        fixed64  = "fixed64" .     rpc        = "rpc" .
+string   = "string" .      sfixed32 = "sfixed32" .    stream     = "stream" .
+bytes    = "bytes" .       sfixed64 = "sfixed64" .    returns    = "returns" .
+group    = "group" .       enum     = "enum" .
 ```
 
 #### Numeric Literals


### PR DESCRIPTION
`inf` is not a real keyword in Protobuf; it's part of textformat, which gloms onto Protobuf in a slightly odd way. The same is true of `nan`, `true`, `false` (and `True`, `False`, `T`, and `F`), which are not listed as keywords. It seems best to keep them separate.

Ideally, the production for `option` should simply say "the value is any textformat value", but that does not match what `protoc` does today. I'd like for us to fix that in the fullness of time, but that seems out of scope for this change.