### PR TITLE
Fix several minor things

### DIFF
--- a/docs/descriptors.md
+++ b/docs/descriptors.md
@@ -366,10 +366,10 @@ known options are emitted first, in field number order. But unknown options (whi
 includes all custom options/extensions), each single option declaration is encoded
 to bytes as if it were by itself. The resulting binary form relies heavily on the
 fact that the binary encoding will merge data. So the bytes for each custom option
-are unmarshalled, such that the bytes from a later option get merged into the
-results from unmarshalling earlier ones. The result is that the two examples below
+are unmarshaled, such that the bytes from a later option get merged into the
+results from unmarshaling earlier ones. The result is that the two examples below
 are encoded to bytes very differently, but the resulting options messages after
-unmarshalling either are semantically equivalent.
+unmarshaling either are semantically equivalent.
 
 ```protobuf title="destructured.proto"
 // This example de-structures the option across multiple declarations:
@@ -1064,7 +1064,7 @@ The [_MapFieldDecl_](./language-spec.md#maps) production results in both a
 _and_ a [`DescriptorProto`](https://github.com/protocolbuffers/protobuf/blob/v27.0/src/google/protobuf/descriptor.proto#L134).
 
 The spec describes how map fields behave as if they were defined as a repeated
-field whose type is a map entry message. The message has two fields: a key and a value. 
+field whose type is a map entry message. The message has two fields: a key and a value.
 The spec includes an example that demonstrates exactly how the field is represented in
 the descriptor: as a repeated field and a nested message. Here's that example again:
 ```protobuf
@@ -1764,7 +1764,7 @@ Any other comments in the array are also detached.
 // This is a leading comment for the "option" keyword token. But it's
 // also a leading comment for the entire option declaration.
 option java_package = "foo.bar.baz";
-// This is a trailing comment for the ";" puncutation token. But it's
+// This is a trailing comment for the ";" punctuation token. But it's
 // also a trailing comment for the entire option declaration.
 ```
 

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -1475,7 +1475,7 @@ Below are the meta-options:
 3. [`edition_defaults`](https://github.com/protocolbuffers/protobuf/blob/v27.0/src/google/protobuf/descriptor.proto#L763-L767):
    This option is required for feature fields and is used to to resolve feature values.
    This is described in more detail [below](#feature-defaults).
- 
+
 4. [`feature_support`](https://github.com/protocolbuffers/protobuf/blob/v27.0/src/google/protobuf/descriptor.proto#L772-L792):
    This option is also required for feature fields and defines the range of editions in
    which a feature field may be used. This is described in more detail [below](#feature-lifetimes).
@@ -2088,7 +2088,7 @@ number in the range.
 
 :::tip
 
-When creating messages, authors should prefer lower numbers: unmarshalling a message is
+When creating messages, authors should prefer lower numbers: unmarshaling a message is
 typically optimized for smaller field numbers. Also, smaller values are more efficiently
 encoded and decoded: field numbers 1 to 15 can be encoded in a single byte. So it is
 recommended to always start numbering fields at 1 and to use smaller values for more
@@ -2268,7 +2268,7 @@ zero value for a non-repeated field depends on the field's type:
 | _enum types_         | _the first value defined in the enum_ * |
 | _message types_      | `{}` (empty message)                    |
 
-__*__ In proto3 syntax (and for open enums in edition syntax), the first value 
+__*__ In proto3 syntax (and for open enums in edition syntax), the first value
 in an enum _must_ have a numeric value of zero. So, in proto3, the default value
 of an enum field is always the one with a value of zero.
 
@@ -2759,7 +2759,7 @@ Each declaration has the following fields:
 * `repeated`: Must be set to true only if the extension is a repeated field.
 * `reserved`: This is used to reserve a number and prevent its use. This is typically
   done for deleted extensions, to prevent later re-use of the number. If this value is
-  true, `full_name` and `type` must not be set. Conversly, if this value is true,
+  true, `full_name` and `type` must not be set. Conversely, if this value is true,
   `full_name` and `type` must be present.
 
 Unverified ranges may not have any declarations. So it is an error for the `verification`
@@ -3138,7 +3138,7 @@ The extended message is also known as the "extendee".
 An `extend` block must contain at least one field or group.
 
 :::info
-️
+
 Files using proto3 or Editions syntax are not allowed to include _GroupDecl_ elements.
 
 Files using the proto3 syntax are only allowed to declare extensions that
@@ -3345,7 +3345,7 @@ This replaces the `packed` field option, which may only be used in files that us
 proto2 or proto3 syntax. Files that use Editions syntax must use this feature instead.
 
 It is an error to use the `repeated_field_encoding` feature on a non-repeated field
-or an a repeated field whose type cannot use the compact encoding. Only primitive
+or a repeated field whose type cannot use the compact encoding. Only primitive
 numeric fields (which includes bools and enums) can use the compact encoding. Fields
 whose type is a message, group, string, or bytes may not use this feature. This also
 means that map fields may not use this feature (under the hood, they are represented
@@ -3759,7 +3759,7 @@ enum Test {
 ```
 
 This custom feature is **NOT** defined in a well-known import. It is defined in an
-import named`"google/protobuf/go_features.proto"` as a field inside the `(pb.go)`
+import named `"google/protobuf/go_features.proto"` as a field inside the `(pb.go)`
 extension. The authoritative source for this file's content is the repo at
 https://github.com/protocolbuffers/protobuf-go.
 


### PR DESCRIPTION
* Prefer 'unmarshal' to 'unmarshall' (for consistency with protobuf)
* Fix a couple typos
* Add a space between word & backtick